### PR TITLE
Add possibility to attach Excel files to an existing mapper instance

### DIFF
--- a/ExcelMapper.Tests/Tests.cs
+++ b/ExcelMapper.Tests/Tests.cs
@@ -2535,5 +2535,59 @@ namespace Ganss.Excel.Tests
                 Assert.AreEqual(products[i].Num.Number, productsFetched[i].Num.Number);
             }
         }
+
+        [Test]
+        public void AttachWithPathUsingFetchTest()
+        {
+            var mapper = new ExcelMapper();
+
+            mapper.Attach(@"..\..\..\products.xlsx");
+
+            var products = mapper.Fetch<Product>();
+
+            CollectionAssert.AreEqual(new List<Product>
+            {
+                new Product { Name = "Nudossi", NumberInStock = 60, Price = 1.99m, Value = "C2*D2" },
+                new Product { Name = "Halloren", NumberInStock = 33, Price = 2.99m, Value = "C3*D3" },
+                new Product { Name = "Filinchen", NumberInStock = 100, Price = 0.99m, Value = "C5*D5" },
+            }, products);
+        }
+
+        [Test]
+        public void AttachWithStreamUsingFetchTest()
+        {
+            var stream = new FileStream(@"..\..\..\products.xlsx", FileMode.Open, FileAccess.Read);
+            var mapper = new ExcelMapper();
+
+            mapper.Attach(stream);
+
+            var products = mapper.Fetch<Product>();
+
+            CollectionAssert.AreEqual(new List<Product>
+            {
+                new Product { Name = "Nudossi", NumberInStock = 60, Price = 1.99m, Value = "C2*D2" },
+                new Product { Name = "Halloren", NumberInStock = 33, Price = 2.99m, Value = "C3*D3" },
+                new Product { Name = "Filinchen", NumberInStock = 100, Price = 0.99m, Value = "C5*D5" },
+            }, products);
+            stream.Close();
+        }
+
+        [Test]
+        public void AttachWithWorkbookUsingFetchTest()
+        {
+            var workbook = WorkbookFactory.Create(@"..\..\..\products.xlsx");
+            var mapper = new ExcelMapper();
+
+            mapper.Attach(workbook);
+
+            var products = mapper.Fetch<Product>();
+
+            CollectionAssert.AreEqual(new List<Product>
+            {
+                new Product { Name = "Nudossi", NumberInStock = 60, Price = 1.99m, Value = "C2*D2" },
+                new Product { Name = "Halloren", NumberInStock = 33, Price = 2.99m, Value = "C3*D3" },
+                new Product { Name = "Filinchen", NumberInStock = 100, Price = 0.99m, Value = "C5*D5" },
+            }, products);
+        }
     }
 }

--- a/ExcelMapper/ExcelMapper.cs
+++ b/ExcelMapper/ExcelMapper.cs
@@ -158,6 +158,33 @@ namespace Ganss.Excel
         }
 
         /// <summary>
+        /// Attaches the Excel file from the provided <see cref="IWorkbook"/>.
+        /// </summary>
+        /// <param name="workbook">The workbook.</param>
+        public void AttachFile(IWorkbook workbook)
+        {
+            Workbook = workbook;
+        }
+
+        /// <summary>
+        /// Attaches the Excel file from the provided path.
+        /// </summary>
+        /// <param name="file">The path to the Excel file.</param>
+        public void AttachFile(string file)
+        {
+            Workbook = WorkbookFactory.Create(file);
+        }
+
+        /// <summary>
+        /// Attaches the Excel file read from the provided <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">The stream the Excel file is read from.</param>
+        public void AttachFile(Stream stream)
+        {
+            Workbook = WorkbookFactory.Create(stream);
+        }
+
+        /// <summary>
         /// Sets a factory function to create objects of type <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">The type of objects to create.</typeparam>

--- a/ExcelMapper/ExcelMapper.cs
+++ b/ExcelMapper/ExcelMapper.cs
@@ -161,7 +161,7 @@ namespace Ganss.Excel
         /// Attaches the Excel file from the provided <see cref="IWorkbook"/>.
         /// </summary>
         /// <param name="workbook">The workbook.</param>
-        public void AttachFile(IWorkbook workbook)
+        public void Attach(IWorkbook workbook)
         {
             Workbook = workbook;
         }
@@ -170,7 +170,7 @@ namespace Ganss.Excel
         /// Attaches the Excel file from the provided path.
         /// </summary>
         /// <param name="file">The path to the Excel file.</param>
-        public void AttachFile(string file)
+        public void Attach(string file)
         {
             Workbook = WorkbookFactory.Create(file);
         }
@@ -179,7 +179,7 @@ namespace Ganss.Excel
         /// Attaches the Excel file read from the provided <see cref="Stream"/>.
         /// </summary>
         /// <param name="stream">The stream the Excel file is read from.</param>
-        public void AttachFile(Stream stream)
+        public void Attach(Stream stream)
         {
             Workbook = WorkbookFactory.Create(stream);
         }


### PR DESCRIPTION
It can be useful to configure the mapper once for several Excel files.